### PR TITLE
Find `python-config` from PATH properly

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -78,7 +78,7 @@ if test "${PYTHON_LIBS+set}" = set; then
   AC_MSG_NOTICE([PYTHON_LIBS overridden to: $PYTHON_LIBS])
 else
   AC_MSG_CHECKING([for Python library linker flags])
-  PYTHON_LIBS=`$PYTHON-config --ldflags`
+  PYTHON_LIBS=`$PYTHON_CONFIG --ldflags`
   AC_MSG_RESULT([$PYTHON_LIBS])
 fi
 

--- a/m4/am-check-python-headers.m4
+++ b/m4/am-check-python-headers.m4
@@ -4,14 +4,19 @@ dnl function also defines PYTHON_INCLUDES
 AC_DEFUN([AM_CHECK_PYTHON_HEADERS],
 [AC_REQUIRE([AM_PATH_PYTHON])
 
+AC_PATH_PROGS([PYTHON_CONFIG], [python${PYTHON_VERSION}-config python-config], [no])
+if test "${PYTHON_CONFIG}" = "no"; then
+  AC_MSG_ERROR([cannot find python${PYTHON_VERSION}-config or python-config in PATH])
+fi
+
 AC_ARG_VAR([PYTHON_INCLUDES], [CPPFLAGS for Python, overriding output of python2.x-config --includes, e.g. "-I/opt/misc/include/python2.7"])
 
 if test "${PYTHON_INCLUDES+set}" = set; then
   AC_MSG_NOTICE([PYTHON_INCLUDES overridden to: $PYTHON_INCLUDES])
 else
   dnl deduce PYTHON_INCLUDES
-  AC_MSG_CHECKING(for Python headers using $PYTHON-config --includes)
-  PYTHON_INCLUDES=`$PYTHON-config --includes`
+  AC_MSG_CHECKING(for Python headers using $PYTHON_CONFIG --includes)
+  PYTHON_INCLUDES=`$PYTHON_CONFIG --includes`
   if test $? = 0; then
     AC_MSG_RESULT($PYTHON_INCLUDES)
   else


### PR DESCRIPTION
Expecting `python-config` at the same directory as `python` executable would not be suitable if user is using virtualenv.
